### PR TITLE
Allow containers 0.6.4

### DIFF
--- a/containers-unicode-symbols.cabal
+++ b/containers-unicode-symbols.cabal
@@ -47,7 +47,7 @@ library
     build-depends: containers >= 0.4 && < 0.5
     cpp-options: -DCONTAINERS_OLD
   else
-    build-depends: containers >= 0.5 && < 0.6.3
+    build-depends: containers >= 0.5 && < 0.6.5
     exposed-modules: Data.IntMap.Strict.Unicode
                    , Data.Map.Strict.Unicode
 


### PR DESCRIPTION
Tested to build fine with containers 0.6.4.1, which allows building with GHC 8.10.5.